### PR TITLE
Correct method name

### DIFF
--- a/app/client/meillisearch.py
+++ b/app/client/meillisearch.py
@@ -38,7 +38,7 @@ class MeilisearchManager:
         """
         if self._client:
             try:
-                await self._client.close()
+                await self._client.aclose()
             except AttributeError:
                 # If the client does not support closing, ignore this.
                 pass


### PR DESCRIPTION
The close method for `AsyncClient` is `aclose` instead of `close`.